### PR TITLE
ImageTheme fixes

### DIFF
--- a/src/content/docs/hardware/Runcam/VTX/runcam-wifilink-v1.mdx
+++ b/src/content/docs/hardware/Runcam/VTX/runcam-wifilink-v1.mdx
@@ -2,6 +2,7 @@
 title: "Runcam WiFiLink 1"
 description: "Runcam WiFiLink V1 documentation page for OpenIPC wiki"
 ---
+import ThemeImage from '/src/components/ThemeImage.astro'
 
 ![image](/src/assets/images/runcam-wifilink-v1-main-photo.png)
 

--- a/src/content/docs/hardware/Runcam/VTX/runcam-wifilink-v2.mdx
+++ b/src/content/docs/hardware/Runcam/VTX/runcam-wifilink-v2.mdx
@@ -2,6 +2,7 @@
 title: "Runcam WiFiLink 2"
 description: "Runcam WiFiLink 2 documentation page for OpenIPC wiki"
 ---
+import ThemeImage from '/src/components/ThemeImage.astro'
 
 ![image](/src/assets/images/runcam-wifilink-v2-main-photo.png)
 

--- a/src/content/docs/use-cases/fpv/Net cards/rtl8812eu.mdx
+++ b/src/content/docs/use-cases/fpv/Net cards/rtl8812eu.mdx
@@ -2,6 +2,7 @@
 title: "RTL8812EU"
 description: "RTL8812EU documentation page for OpenIPC wiki"
 ---
+import ThemeImage from '/src/components/ThemeImage.astro'
 
 RTL8812EU is new, cheap, widely used WiFi chip. Which can be found on wide variety of WiFi adapters.
 This WiFi chip was released not a long ago, driver capabilities are limited for now, so 5MHz, 10MHz, 20MHz transmit modes is supported right now. On this page you can find information about known WiFi adapters with this chip.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/efe7e45c-d7e9-4f8e-a804-9754f725656f)
This PR fixes this issue. Issue was that ImageTheme must be loaded after frontmatter AKA like this 


`---`
`title: "RTL8812EU"`
`description: "RTL8812EU documentation page for OpenIPC wiki"`
`---`
`import ThemeImage from '/src/components/ThemeImage.astro'`
But `yarn dev` would work even if you forgot to import ImageTheme, so before PR it is highly recommended to execute `yarn build`.
