### PR TITLE
Add info to quick start page

### DIFF
--- a/src/content/docs/getting-started/quick-start.md
+++ b/src/content/docs/getting-started/quick-start.md
@@ -1,4 +1,8 @@
 ---
 title: Quick Start
-description: A guide in my new Starlight docs site.
+description: The fastest path to get started with OpenIPC
 ---
+
+Want to try out OpenIPC? If your camera is supported, you may be able to flash it with its stock firmware update process using an image from [Coupler.](https://github.com/openipc/coupler/)
+
+Otherwise, check the [recommended hardware list](https://openipc.org/supported-hardware/featured) for your camera's SoC to generate an example installation guide using a serial connection and U-Boot.

--- a/src/content/docs/getting-started/quick-start.md
+++ b/src/content/docs/getting-started/quick-start.md
@@ -3,6 +3,4 @@ title: Quick Start
 description: The fastest path to get started with OpenIPC
 ---
 
-Want to try out OpenIPC? If your camera is supported, you may be able to flash it with its stock firmware update process using an image from [Coupler.](https://github.com/openipc/coupler/)
-
-Otherwise, check the [recommended hardware list](https://openipc.org/supported-hardware/featured) for your camera's SoC to generate an example installation guide using a serial connection and U-Boot.
+Want to try out OpenIPC? Check the [recommended hardware list](https://openipc.org/supported-hardware/featured) for your SoC to generate an example installation guide or take a look at the **Use Cases** section for more information depending on your use case.


### PR DESCRIPTION
I thought this might be a good start to the Quick Start section under Getting Started. Since there are so many ways to go about installing OpenIPC, I chose what I believe are the two easiest resources as including everything within "Quick Start" may defeat the purpose of a guide that's supposed to get the user on the right track as simply as possible.