### PR TITLE
Improved groundstation-ubuntu.md with detailed setup steps

### DIFF
--- a/src/content/docs/use-cases/fpv/wfb-ng/groundstation-ubuntu.md
+++ b/src/content/docs/use-cases/fpv/wfb-ng/groundstation-ubuntu.md
@@ -1,24 +1,37 @@
 ---
 title: GroundStation on Ubuntu 22.04
-description: A guide designed to provide a detailed walkthrough for setting up the groundstation on Ubuntu
+description: A guide for setting up a WFB-NG based groundstation on Ubuntu 22.04
 ---
 
 Video version: - [OpenIPC - Prepare GroundStation: Ubuntu + QGroundControl](https://www.youtube.com/watch?v=JMtRAsOm0Dc)
 
-## Prepare
+## Prepare Ubuntu 22.04
+Wifi drivers require compilation for specific linux kernels, Ubuntu 22.04 (jammy) ships with Linux 5.15 LTS kernel. Newer Ubuntu versions will break the wifi card drivers. 
 
+**Download and install Ubuntu 22.04 (Jammy)**
+
+[Ubuntu 22.04.5 LTS (Jammy Jellyfish)](https://releases.ubuntu.com/jammy/)
+
+**update apt and install required packages**
 ```
 sudo apt update
 ```
 
 ```
 sudo apt install dkms git python3-all-dev net-tools virtualenv fakeroot debhelper python3-twisted \
- libpcap-dev python3-pyroute2 python3-future python3-configparser python3-all libsodium-dev
+ libpcap-dev python3-pyroute2 python3-future python3-all
 ```
 
-## Libsodium
+## Install Libsodium
+Libsodium is used to encrypt data sent through the wfb-ng pipeline. It can be installed either via apt, or by building it directly from the latest stable source. 
 
+**Install from apt.**
 ```
+sudo apt install libsodium-dev
+```
+**Install from source.**
+```
+cd
 git clone https://github.com/jedisct1/libsodium --branch stable
 cd libsodium
 ./configure
@@ -27,58 +40,166 @@ sudo make install
 ```
 
 ## Wifi card driver
+svpcom's rtl8812au and rtl8812eu wifi drivers offer superior performance for wfb-ng compared to standard rtl8812au/eu drivers. To use a usb rtl8812au or rt8812eu wifi card, you need to install their respective drivers.
 
+**Install rtl8812au driver from source:**
 ```
+cd
 git clone -b v5.2.20 https://github.com/svpcom/rtl8812au.git
 cd rtl8812au/
 sudo ./dkms-install.sh
 ```
 
-## WFB-NG
-
+**Install rtl8812eu driver from source:**
 ```
+cd
+git clone -b v5.15.0.1 https://github.com/svpcom/rtl8812eu.git
+cd rtl8812eu/
+sudo ./dkms-install.sh
+```
+
+As long as your usb wifi cards were not plugged in when Ubuntu was installed, you should not have any driver conflicts with stock realtek drivers.
+
+## WFB-NG
+WFB-NG can be installed via apt, or from source.
+
+**Install WFB-NG from apt.**
+```
+curl -s https://apt.wfb-ng.org/public.asc | sudo gpg --dearmor --yes -o /usr/share/keyrings/wfb-ng.gpg
+echo "deb [signed-by=/usr/share/keyrings/wfb-ng.gpg] https://apt.wfb-ng.org/ $(lsb_release -cs) master" | sudo tee /etc/apt/sources.list.d/wfb-ng.list
+sudo apt update
+sudo apt install wfb-ng -y
+```
+
+**Install WFB-NG from source.**
+
+First with the usb wifi card plugged in, determine its wireless interface name:
+```
+sudo apt install wireless-tools -y
+iwconfig
+```
+You will see something like this:
+```
+:~$ iwconfig
+lo        no wireless extensions.
+
+enp1s0    no wireless extensions.
+
+wlxc8fe0f5e5805  IEEE 802.11  ESSID:off/any
+          Mode:Managed  Access Point: Not-Associated   Tx-Power=18 dBm
+          Retry short limit:7   RTS thr:off   Fragment thr:off
+          Power Management:off
+```
+In this case, the rtl8812au wireless interface name is wlxc8fe0f5e5805
+```
+cd
 git clone -b stable https://github.com/svpcom/wfb-ng.git
 cd wfb-ng
-sudo ./scripts/install_gs.sh wlan0
+sudo ./scripts/install_gs.sh "wireless_interface_name"  
 ```
 
 ## Channel configuration
-
+WFB-NG operates according to config settings set in /etc/wifibroadcast.cfg use this config to set the correct key, channel, and output power, etc. If you installed wfb-ng via apt, you will need to create this config file manually.
 ```
-vi /etc/wifibroadcast.cfg
+sudo touch /etc/wifibroadcast.cfg
+sudo nano /etc/wifibroadcast.cfg
+```
+default `/etc/wifibroadcast.cfg` contents
+```
+[common]
+wifi_channel = 165     # 165 -- radio channel @5825 MHz, range: 5815-5835 MHz, width 20MHz
+                       # 1 -- radio channel @2412 Mhz,
+                       # see https://en.wikipedia.org/wiki/List_of_WLAN_channels for reference
+wifi_region = 'BO'     # Your country for CRDA (use BO or GY if you want max tx power)
+
+[gs_mavlink]
+peer = 'connect://127.0.0.1:14550'  # outgoing connection
+# peer = 'listen://0.0.0.0:14550'   # incoming connection
+
+[gs_video]
+peer = 'connect://127.0.0.1:5600'  # outgoing connection for
+                                   # video sink (QGroundControl on GS)
 ```
 
-## Start WFB CLI
-
+WFB-NG also refers to `/etc/modprobe.d/wfb.conf`. If you installed wfb-ng via apt, you will need to create this file manually as well. 
 ```
-wfb-cli gs
+sudo touch /etc/modprobe.d/wfb.conf
+sudo nano /etc/modprobe.d/wfb.conf
 ```
 
-######GS IS READY FOR USE######
-
-## Start, stop, restart service
-
+default `/etc/modprobe.d/wfb.conf` contents
 ```
-systemctl status wifibroadcast@gs
-systemctl stop wifibroadcast@gs
+# blacklist stock module
+blacklist 88XXau
+blacklist 8812au
+blacklist 8812
+options cfg80211 ieee80211_regdom=RU
+# maximize output power by default
+#options 88XXau_wfb rtw_tx_pwr_idx_override=30
+# minimize output power by default
+options 88XXau_wfb rtw_tx_pwr_idx_override=1
+options 8812eu rtw_tx_pwr_by_rate=0 rtw_tx_pwr_lmt_enable=0
+```
+
+## Start, stop, restart WFB-NG service
+Now with everything installed, you can run WFB-NG as a system service.
+
+Start WFB-NG:
+```
 systemctl start wifibroadcast@gs
 ```
 
-## Qground control manual
+Stop WFB-NG:
+```
+systemctl stop wifibroadcast@gs
+```
 
-- https://docs.qgroundcontrol.com/master/en/getting_started/download_and_install.html
+Check the status of WFB-NG:
+```
+systemctl status wifibroadcast@gs
+```
 
-## Get last logs from service
+Make WFB-NG start at boot:
+```
+systemctl enable wifibroadcast@gs
+```
 
+Get the last logs from WFB-NG service:
 ```
 journalctl -xu wifibroadcast@gs -n 100
 ```
 
-## Useful commands
+## Start WFB CLI
+WFB-NG comes with a cli utility that allows you to see WFB-NG's status in real time in a nicely formatted menu
+
+Note, this is not the same as running WFB-NG, nor is it required to use WFB-NG. It is however, very helpful.
+```
+wfb-cli gs
+```
+
+
+## Connecting to QgroundControl
+If you have not done so already, install QgroundControl on the device/s you wish
+
+[QGroundControl Download and Install](https://docs.qgroundcontrol.com/master/en/getting_started/download_and_install.html)
+
+WFB-NG is able to send UDP video, and MAVLink streams to any device on your network using its IP Address. The default config uses the localhost IP Address 127.0.0.1 which keeps data streams on-device, this works well if you have QGroundControl installed locally. If you have QgroundControl installed on a different device, use that device's IP address instead.
 
 ```
-nmcli
-ifconfig
-iwconfig
-
+sudo nano /etc/wifibroadcast.cfg
 ```
+modify `/etc/wifibroadcast.cfg` contents
+```
+[gs_mavlink]
+peer = 'connect://your_device_IP_address:14550'
+
+[gs_video]
+peer = 'connect://your_device_IP_address:5600'
+```
+
+When you open QGroundControl, it should automatically connect to the UDP MAVLink stream, If it doesn't, make sure your IP Address matches the `/etc/wfibroadcast.cfg', and make sure your firewall rules correctly let QGroundControl connect to devices on your local network. 
+
+To add a video stream, open the video tab, choose `UDP h.265 Video Stream` as your source, set the URL to `0.0.0.0:5600`, and enable `Low Latency Mode`.  
+
+<img width="496" height="742" alt="QGroundControl-Video-Stream-Settings" src="https://github.com/user-attachments/assets/53f03364-7fe2-4b3b-bcb3-11d871b128e7" />
+

--- a/src/content/docs/use-cases/fpv/wfb-ng/groundstation-ubuntu.md
+++ b/src/content/docs/use-cases/fpv/wfb-ng/groundstation-ubuntu.md
@@ -61,17 +61,9 @@ sudo ./dkms-install.sh
 As long as your usb wifi cards were not plugged in when Ubuntu was installed, you should not have any driver conflicts with stock realtek drivers.
 
 ## WFB-NG
-WFB-NG can be installed via apt, or from source.
+WFB-NG can be installed automatically via its setup script.
 
-**Install WFB-NG from apt.**
-```
-curl -s https://apt.wfb-ng.org/public.asc | sudo gpg --dearmor --yes -o /usr/share/keyrings/wfb-ng.gpg
-echo "deb [signed-by=/usr/share/keyrings/wfb-ng.gpg] https://apt.wfb-ng.org/ $(lsb_release -cs) master" | sudo tee /etc/apt/sources.list.d/wfb-ng.list
-sudo apt update
-sudo apt install wfb-ng -y
-```
-
-**Install WFB-NG from source.**
+**Install WFB-NG from script.**
 
 First with the usb wifi card plugged in, determine its wireless interface name:
 ```
@@ -99,7 +91,7 @@ sudo ./scripts/install_gs.sh "wireless_interface_name"
 ```
 
 ## Channel configuration
-WFB-NG operates according to config settings set in /etc/wifibroadcast.cfg use this config to set the correct key, channel, and output power, etc. If you installed wfb-ng via apt, you will need to create this config file manually.
+WFB-NG operates according to config settings set in /etc/wifibroadcast.cfg use this config to set the channel, wifi region, and to route video and mavlink udp.
 ```
 sudo touch /etc/wifibroadcast.cfg
 sudo nano /etc/wifibroadcast.cfg
@@ -119,26 +111,6 @@ peer = 'connect://127.0.0.1:14550'  # outgoing connection
 [gs_video]
 peer = 'connect://127.0.0.1:5600'  # outgoing connection for
                                    # video sink (QGroundControl on GS)
-```
-
-WFB-NG also refers to `/etc/modprobe.d/wfb.conf`. If you installed wfb-ng via apt, you will need to create this file manually as well. 
-```
-sudo touch /etc/modprobe.d/wfb.conf
-sudo nano /etc/modprobe.d/wfb.conf
-```
-
-default `/etc/modprobe.d/wfb.conf` contents
-```
-# blacklist stock module
-blacklist 88XXau
-blacklist 8812au
-blacklist 8812
-options cfg80211 ieee80211_regdom=RU
-# maximize output power by default
-#options 88XXau_wfb rtw_tx_pwr_idx_override=30
-# minimize output power by default
-options 88XXau_wfb rtw_tx_pwr_idx_override=1
-options 8812eu rtw_tx_pwr_by_rate=0 rtw_tx_pwr_lmt_enable=0
 ```
 
 ## Start, stop, restart WFB-NG service


### PR DESCRIPTION
Issue: Ubuntu Groundstation install instructions are incomplete and rely on a video to explain commands and install steps.
Fix: Improve instructions, add instructions for rtl8812eu drivers, explain commands, give an example for finding the wireless device name to use for wfb-ng, add apt install instructions.
Closes #104 